### PR TITLE
fix: add node_modules in ignores

### DIFF
--- a/src/eslint.config.ts
+++ b/src/eslint.config.ts
@@ -68,7 +68,7 @@ export default function unjsPreset(
         ),
       },
     },
-    { ignores: ["dist", "coverage", ...(config.ignores || [])] },
+    { ignores: ["dist", "coverage", "node_modules", ...(config.ignores || [])] },
 
     // Markdown
     // https://www.npmjs.com/package/eslint-plugin-markdown


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

related https://github.com/unjs/citty/pull/150#discussion_r1666653201

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The review comment pointed out the lack of `node_modules`. : https://github.com/unjs/citty/pull/150#discussion_r1666653201

Adding `node_modules` to ignores individually is redundant, so this PR was created.