### PR TITLE
chore: migrate from deprecated ESLint APIs

### DIFF
--- a/src/eslint.config.ts
+++ b/src/eslint.config.ts
@@ -52,7 +52,7 @@ export default function unjsPreset(
     // https://typescript-eslint.io/
     ...(tseslint.configs.recommended as Linter.Config[]),
     // https://github.com/sindresorhus/eslint-plugin-unicorn
-    eslintPluginUnicorn.configs["flat/recommended"] as Linter.Config,
+    eslintPluginUnicorn.configs.recommended as Linter.Config,
 
     // Preset overrides
     { rules: rules as Linter.RulesRecord },

--- a/src/eslint.config.ts
+++ b/src/eslint.config.ts
@@ -14,7 +14,7 @@ export interface MainConfig {
   ignores?: string[];
 }
 
-export interface TypedFlatConfig extends Omit<Linter.FlatConfig, "rules"> {
+export interface TypedFlatConfig extends Omit<Linter.Config, "rules"> {
   rules?: RuleOptions;
 }
 
@@ -46,13 +46,13 @@ export default function unjsPreset(
     ...config.rules,
   };
 
-  const configs: Linter.FlatConfig[] = [
+  const configs: Linter.Config[] = [
     // https://eslint.org/docs/latest/rules/
     eslint.configs.recommended,
     // https://typescript-eslint.io/
-    ...(tseslint.configs.recommended as Linter.FlatConfig[]),
+    ...(tseslint.configs.recommended as Linter.Config[]),
     // https://github.com/sindresorhus/eslint-plugin-unicorn
-    eslintPluginUnicorn.configs["flat/recommended"] as Linter.FlatConfig,
+    eslintPluginUnicorn.configs["flat/recommended"] as Linter.Config,
 
     // Preset overrides
     { rules: rules as Linter.RulesRecord },
@@ -95,8 +95,8 @@ export default function unjsPreset(
     },
 
     // User overrides
-    ...(userConfigs as Linter.FlatConfig[]),
-  ].filter(Boolean) as Linter.FlatConfig[];
+    ...(userConfigs as Linter.Config[]),
+  ].filter(Boolean) as Linter.Config[];
 
   return configs;
 }


### PR DESCRIPTION
Migrate the deprecated ESLint API to the currently recommended API

refs:

- https://github.com/eslint/eslint/blob/e86b813eb660f1a5adc8e143a70d9b683cd12362/lib/types/index.d.ts#L1053-L1054
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/609d4870f3731d39bd5b5f184628e2cf06578dba/index.d.ts#L12-L13

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
